### PR TITLE
feat: add goreleaser, homebrew tap, and restructure for go install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: sl
+    main: ./cmd/sl
+    binary: sl
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+
+archives:
+  - id: default
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+    files:
+      - LICENSE*
+      - README*
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - Merge pull request
+      - Merge branch
+
+brews:
+  - name: sl
+    repository:
+      owner: mexcool
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/mexcool/simplelogin-cli"
+    description: "SimpleLogin CLI — manage email aliases from the terminal"
+    license: "MIT"
+    install: |
+      bin.install "sl"
+    test: |
+      system "#{bin}/sl", "--version"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION ?= dev
 
 build:
-	go build -ldflags="-s -w -X main.version=$(VERSION)" -o bin/sl .
+	go build -ldflags="-s -w -X main.version=$(VERSION)" -o bin/sl ./cmd/sl
 
 install: build
 	cp bin/sl /usr/local/bin/sl

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ A command-line interface for the [SimpleLogin](https://simplelogin.io) email ali
 
 ## Installation
 
+### Homebrew (macOS/Linux)
+
+```bash
+brew tap mexcool/tap
+brew install sl
+```
+
+### Go install
+
+```bash
+go install github.com/mexcool/simplelogin-cli/cmd/sl@latest
+```
+
+### GitHub Releases
+
+Download pre-built binaries for your platform from the [Releases](https://github.com/mexcool/simplelogin-cli/releases) page.
+
 ### From source
 
 ```bash
@@ -11,19 +28,6 @@ git clone https://github.com/mexcool/simplelogin-cli.git
 cd simplelogin-cli
 make build
 # Binary is at ./bin/sl
-```
-
-### Go install
-
-```bash
-go install github.com/mexcool/simplelogin-cli@latest
-```
-
-### System-wide
-
-```bash
-make install
-# Copies bin/sl to /usr/local/bin/sl
 ```
 
 ## Authentication

--- a/cmd/sl/main.go
+++ b/cmd/sl/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"runtime/debug"
 
 	"github.com/mexcool/simplelogin-cli/cmd"
 )
@@ -9,6 +10,11 @@ import (
 var version = "dev"
 
 func main() {
+	if version == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" {
+			version = info.Main.Version
+		}
+	}
 	cmd.SetVersion(version)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
## Summary

- Move `main.go` → `cmd/sl/main.go` so `go install github.com/mexcool/simplelogin-cli/cmd/sl@latest` produces a binary named `sl`
- Add `.goreleaser.yaml` for cross-platform release builds (linux/darwin/windows, amd64/arm64) with homebrew formula auto-publishing to `mexcool/homebrew-tap`
- Add `.github/workflows/release.yml` triggered on `v*` tags
- Add `runtime/debug.ReadBuildInfo()` fallback for version detection via `go install`
- Update README install instructions with homebrew, go install, GitHub Releases, and build from source

## Test plan

- [x] `make build` produces `bin/sl`
- [x] `./bin/sl --version` works
- [x] `./bin/sl --help` works
- [x] `goreleaser check` validates config
- [x] `goreleaser release --snapshot --clean` builds all 6 archives successfully
- [x] After merge: add `HOMEBREW_TAP_GITHUB_TOKEN` secret, tag `v0.1.0`, verify release workflow

Closes #3