### PR TITLE
fix: upgrade to GenBashCompletionV2 for bash completions. Closes #11

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,7 @@ var completionCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		switch args[0] {
 		case "bash":
-			return rootCmd.GenBashCompletion(os.Stdout)
+			return rootCmd.GenBashCompletionV2(os.Stdout, true)
 		case "zsh":
 			return rootCmd.GenZshCompletion(os.Stdout)
 		case "fish":


### PR DESCRIPTION
## Summary

- Replaces the deprecated `GenBashCompletion` with `GenBashCompletionV2` in the `completion bash` command.
- Enables descriptions (`true` flag) so users get contextual help alongside completions.

## Files changed

- `cmd/root.go`: updated `case "bash":` to call `rootCmd.GenBashCompletionV2(os.Stdout, true)`.