### PR TITLE
fix: respect XDG_CONFIG_HOME for config file location. Closes #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export SL_API_KEY=your_api_key_here
 
 ```bash
 sl auth login --key sl_xxxxxxxxxxxxx
-# Stored in ~/.config/simplelogin/config.yml
+# Stored in $XDG_CONFIG_HOME/simplelogin/config.yml (defaults to ~/.config/simplelogin/config.yml)
 ```
 
 Or interactively:
@@ -264,7 +264,7 @@ sl export data | jq '.aliases | length'
 
 ## Configuration
 
-Config file location: `~/.config/simplelogin/config.yml`
+Config file location: `$XDG_CONFIG_HOME/simplelogin/config.yml` (defaults to `~/.config/simplelogin/config.yml`)
 
 ```yaml
 api_key: sl_xxxxxxxxxxxxx

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -21,7 +21,7 @@ There are three ways to authenticate:
 
 1. Direct API key:
    Provide your API key directly. It will be stored in
-   ~/.config/simplelogin/config.yml.
+   $XDG_CONFIG_HOME/simplelogin/config.yml (defaults to ~/.config/simplelogin/config.yml).
 
 2. 1Password integration:
    Store a reference to your API key in 1Password. The CLI will

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -12,7 +12,7 @@ var logoutCmd = &cobra.Command{
 	Short: "Remove stored credentials",
 	Long: `Remove stored API key and 1Password references from the config file.
 
-This command clears stored credentials from ~/.config/simplelogin/config.yml.
+This command clears stored credentials from $XDG_CONFIG_HOME/simplelogin/config.yml (defaults to ~/.config/simplelogin/config.yml).
 It also attempts to invalidate the API session on the server.
 
 Note: This does not affect environment variables (SIMPLELOGIN_API_KEY, SL_API_KEY).

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ Authentication:
   1. SIMPLELOGIN_API_KEY environment variable
   2. SL_API_KEY environment variable
   3. 1Password CLI (if configured via sl auth login --1password)
-  4. Config file (~/.config/simplelogin/config.yml)
+  4. Config file ($XDG_CONFIG_HOME/simplelogin/config.yml, defaults to ~/.config/simplelogin/config.yml)
 
   Run "sl auth login" to get started.
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -13,11 +13,15 @@ import (
 var configDir string
 
 func init() {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		configDir = ".config/simplelogin"
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		configDir = filepath.Join(xdg, "simplelogin")
 	} else {
-		configDir = filepath.Join(home, ".config", "simplelogin")
+		home, err := os.UserHomeDir()
+		if err != nil {
+			configDir = filepath.Join(".config", "simplelogin")
+		} else {
+			configDir = filepath.Join(home, ".config", "simplelogin")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Updated `internal/auth/auth.go` to check `XDG_CONFIG_HOME` environment variable before falling back to `~/.config/simplelogin/`, per the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/latest/).
- Updated help text in `cmd/root.go`, `cmd/auth/login.go`, and `cmd/auth/logout.go` to document the new behavior.
- Updated `README.md` to reflect that the config path respects `XDG_CONFIG_HOME`.

## Behavior

| `XDG_CONFIG_HOME` | Config path |
|---|---|
| Set (e.g. `/home/user/.myconfig`) | `$XDG_CONFIG_HOME/simplelogin/config.yml` |
| Unset | `~/.config/simplelogin/config.yml` (unchanged default) |

This is fully backward-compatible: users who don't set `XDG_CONFIG_HOME` see no change.

## Files changed

- `internal/auth/auth.go` — core fix in the `init()` function
- `cmd/root.go` — root command help text
- `cmd/auth/login.go` — login command help text
- `cmd/auth/logout.go` — logout command help text
- `README.md` — documentation