### PR TITLE
feat: add man page generation. Closes #14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Build output
 bin/
 
+# Generated man pages
+man/
+
 # Go
 *.test
 *.out

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,7 @@ version: 2
 before:
   hooks:
     - go mod tidy
+    - go run ./cmd/gen-man man/
 
 builds:
   - id: sl
@@ -40,6 +41,7 @@ archives:
     files:
       - LICENSE*
       - README*
+      - man/*.1
 
 checksum:
   name_template: "checksums.txt"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ install: build
 test:
 	go test ./...
 
-clean:
-	rm -rf bin/
+man:
+	go run ./cmd/gen-man man/
 
-.PHONY: build install test clean
+clean:
+	rm -rf bin/ man/
+
+.PHONY: build install test man clean

--- a/cmd/gen-man/main.go
+++ b/cmd/gen-man/main.go
@@ -1,0 +1,51 @@
+// gen-man generates man pages for the sl CLI using cobra/doc.
+// Usage: go run ./cmd/gen-man [output-dir]
+// Default output directory is "man/".
+package main
+
+import (
+	"log"
+	"os"
+	"time"
+
+	"github.com/mexcool/simplelogin-cli/cmd"
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+func main() {
+	outDir := "man"
+	if len(os.Args) > 1 {
+		outDir = os.Args[1]
+	}
+
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		log.Fatalf("failed to create output directory %q: %v", outDir, err)
+	}
+
+	// Build a minimal root command that mirrors the real one, with a fixed
+	// date so the generated pages are deterministic.
+	header := &doc.GenManHeader{
+		Title:   "SL",
+		Section: "1",
+		Date:    func() *time.Time { t := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC); return &t }(),
+		Source:  "SimpleLogin CLI",
+		Manual:  "SimpleLogin CLI Manual",
+	}
+
+	// Execute is exported; use the exported root via a tiny shim so we can
+	// pass a *cobra.Command to GenManTree.
+	root := buildRoot()
+
+	if err := doc.GenManTree(root, header, outDir); err != nil {
+		log.Fatalf("failed to generate man pages: %v", err)
+	}
+
+	log.Printf("man pages written to %s/", outDir)
+}
+
+// buildRoot returns a *cobra.Command that has the same sub-command tree as the
+// real sl binary.  We call cmd.RootCmd() which we expose below.
+func buildRoot() *cobra.Command {
+	return cmd.RootCmd()
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,11 @@ func Execute() error {
 	return rootCmd.Execute()
 }
 
+// RootCmd returns the root cobra.Command, used by tooling such as man page generation.
+func RootCmd() *cobra.Command {
+	return rootCmd
+}
+
 var completionCmd = &cobra.Command{
 	Use:       "completion [bash|zsh|fish|powershell]",
 	Short:     "Generate shell completion scripts",

--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,14 @@ require (
 )
 
 require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -31,6 +32,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=


### PR DESCRIPTION
## Summary

- Adds `cmd/gen-man/main.go` — a small Go program that uses `github.com/spf13/cobra/doc` to generate man pages for all `sl` commands and subcommands into a `man/` directory
- Exports `RootCmd()` from the `cmd` package so the generator can access the fully initialised cobra command tree
- Adds a `make man` target that runs the generator
- Updates `.goreleaser.yaml` to run man page generation before builds and include the resulting `man/*.1` files in release archives
- Adds `man/` to `.gitignore` since the pages are generated artefacts

## How to use

```bash
# Generate man pages locally
make man

# Install a page (example)
sudo cp man/sl.1 /usr/local/share/man/man1/
man sl
```

## Files changed

- `cmd/gen-man/main.go` — new man page generator
- `cmd/root.go` — exposes `RootCmd()` helper
- `Makefile` — new `man` target; `clean` now also removes `man/`
- `.goreleaser.yaml` — before hook + archive files entry for man pages
- `.gitignore` — ignores generated `man/` directory
- `go.mod` / `go.sum` — adds `github.com/spf13/cobra/doc` and its transitive deps