### PR TITLE
fix: embed build info (commit, date) in --version output. Closes #8

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X main.version={{ .Version }}
+      - -s -w -X main.version={{ .Version }} -X main.commit={{ .ShortCommit }} -X main.date={{ .Date }}
 
 archives:
   - id: default

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 VERSION ?= dev
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null)
+DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+
+LDFLAGS := -s -w \
+	-X main.version=$(VERSION) \
+	-X main.commit=$(COMMIT) \
+	-X main.date=$(DATE)
 
 build:
-	go build -ldflags="-s -w -X main.version=$(VERSION)" -o bin/sl ./cmd/sl
+	go build -ldflags="$(LDFLAGS)" -o bin/sl ./cmd/sl
 
 install: build
 	cp bin/sl /usr/local/bin/sl

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/mexcool/simplelogin-cli/cmd/account"
@@ -39,10 +40,34 @@ Output:
 	SilenceErrors: true,
 }
 
-// SetVersion sets the version string shown by --version.
-func SetVersion(v string) {
+// SetVersionInfo sets the version string shown by --version, including
+// optional build metadata (commit hash and build date).
+func SetVersionInfo(v, commit, date string) {
 	version = v
-	rootCmd.Version = v
+	display := v
+	if commit != "" || date != "" {
+		parts := make([]string, 0, 2)
+		if commit != "" {
+			parts = append(parts, commit)
+		}
+		if date != "" {
+			parts = append(parts, date)
+		}
+		display = fmt.Sprintf("%s (%s)", v, joinStrings(parts, ", "))
+	}
+	rootCmd.Version = display
+}
+
+// joinStrings concatenates strings with a separator (avoids importing strings package for one call).
+func joinStrings(elems []string, sep string) string {
+	if len(elems) == 0 {
+		return ""
+	}
+	result := elems[0]
+	for _, e := range elems[1:] {
+		result += sep + e
+	}
+	return result
 }
 
 // Execute runs the root command.

--- a/cmd/sl/main.go
+++ b/cmd/sl/main.go
@@ -7,15 +7,37 @@ import (
 	"github.com/mexcool/simplelogin-cli/cmd"
 )
 
-var version = "dev"
+// These variables are set at build time via ldflags.
+var (
+	version = "dev"
+	commit  = ""
+	date    = ""
+)
 
 func main() {
-	if version == "dev" {
-		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" {
+	// Fallback: when installed via `go install`, ldflags are not set.
+	// Use runtime/debug.ReadBuildInfo to recover version and VCS metadata.
+	// We only override version from build info when no ldflags were injected
+	// at all (commit is empty), to avoid replacing an intentional "dev" value.
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if version == "dev" && commit == "" && info.Main.Version != "" {
 			version = info.Main.Version
 		}
+		for _, s := range info.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				if commit == "" && len(s.Value) >= 7 {
+					commit = s.Value[:7]
+				}
+			case "vcs.time":
+				if date == "" {
+					date = s.Value
+				}
+			}
+		}
 	}
-	cmd.SetVersion(version)
+
+	cmd.SetVersionInfo(version, commit, date)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

- Add `commit` and `date` build-time variables to `cmd/sl/main.go`, injected via `-ldflags`
- Update `cmd/root.go` to format the version string as `X.Y.Z (commit, date)` when build metadata is available
- Update `Makefile` to pass `-X main.commit` and `-X main.date` via ldflags
- Update `.goreleaser.yaml` to inject `ShortCommit` and `Date` into release builds
- Add `runtime/debug.ReadBuildInfo()` fallback so `go install` users still get VCS metadata

### Version output examples

| Build method | Output |
|---|---|
| `make build` | `sl version dev (77620d6, 2026-03-26T19:08:17Z)` |
| goreleaser | `sl version 0.1.0 (abc1234, 2026-03-26)` |
| `go install` | `sl version v0.1.0 (77620d6, 2026-03-26T...)` (from debug info) |

## Files changed

- `cmd/sl/main.go` -- added `commit` and `date` vars with ldflags + ReadBuildInfo fallback
- `cmd/root.go` -- replaced `SetVersion` with `SetVersionInfo` that formats build metadata
- `Makefile` -- added `COMMIT` and `DATE` variables and expanded ldflags
- `.goreleaser.yaml` -- added `main.commit` and `main.date` to ldflags