### PR TITLE
fix: surface errors to users instead of silently swallowing them. Closes #5

### DIFF
--- a/cmd/account/status.go
+++ b/cmd/account/status.go
@@ -46,20 +46,17 @@ func init() {
 func runStatus(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	info, infoJSON, err := client.GetUserInfo()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	stats, statsJSON, err := client.GetStats()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/alias/activity.go
+++ b/cmd/alias/activity.go
@@ -53,21 +53,18 @@ func init() {
 func runActivity(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	id, err := client.ResolveAliasID(args[0])
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	if activityAll {
 		activities, err := client.GetAllAliasActivities(id)
 		if err != nil {
-			output.PrintError("%v", err)
 			return err
 		}
 
@@ -85,7 +82,6 @@ func runActivity(cmd *cobra.Command, args []string) error {
 
 	activities, rawJSON, err := client.GetAliasActivities(id, activityPage-1)
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/alias/create.go
+++ b/cmd/alias/create.go
@@ -65,7 +65,6 @@ func init() {
 func runCreate(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
@@ -74,7 +73,6 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if createRandom {
 		alias, rawJSON, err := client.CreateRandomAlias(createNote)
 		if err != nil {
-			output.PrintError("%v", err)
 			return err
 		}
 
@@ -95,13 +93,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	// Get available options
 	opts, _, err := client.GetAliasOptions()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	if len(opts.Suffixes) == 0 {
-		output.PrintError("No suffixes available. You may need a premium account.")
-		return fmt.Errorf("no suffixes available")
+		return fmt.Errorf("no suffixes available; you may need a premium account")
 	}
 
 	var selectedSuffix api.SuffixOption
@@ -112,9 +108,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			for i, s := range opts.Suffixes {
 				hints = append(hints, fmt.Sprintf("%d: %s%s", i, createPrefix, s.Suffix))
 			}
-			err := fmt.Errorf("--suffix is required in non-interactive mode. Available suffixes:\n  %s", strings.Join(hints, "\n  "))
-			output.PrintError("%v", err)
-			return err
+			return fmt.Errorf("--suffix is required in non-interactive mode; available suffixes:\n  %s", strings.Join(hints, "\n  "))
 		}
 		// Interactive suffix selection
 		fmt.Fprintln(os.Stderr, "Available suffixes:")
@@ -126,7 +120,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		fmt.Scanln(&input)
 		idx, err := strconv.Atoi(strings.TrimSpace(input))
 		if err != nil || idx < 0 || idx >= len(opts.Suffixes) {
-			return fmt.Errorf("invalid suffix selection")
+			return fmt.Errorf("invalid suffix selection; enter a number between 0 and %d", len(opts.Suffixes)-1)
 		}
 		selectedSuffix = opts.Suffixes[idx]
 	} else {
@@ -143,8 +137,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		// Use default mailbox
 		mailboxes, _, err := client.ListMailboxes()
 		if err != nil {
-			output.PrintError("Failed to get mailboxes: %v", err)
-			return err
+			return fmt.Errorf("failed to get mailboxes: %w", err)
 		}
 		for _, m := range mailboxes {
 			if m.Default {
@@ -167,7 +160,6 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	alias, rawJSON, err := client.CreateCustomAlias(req)
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/alias/delete.go
+++ b/cmd/alias/delete.go
@@ -52,22 +52,19 @@ func init() {
 func runDelete(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	id, err := client.ResolveAliasID(args[0])
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	if deleteDryRun {
 		alias, rawJSON, err := client.GetAlias(id)
 		if err != nil {
-			output.PrintError("Failed to fetch alias for preview: %v", err)
-			return err
+			return fmt.Errorf("failed to fetch alias for preview: %w", err)
 		}
 		if deleteJSON {
 			_ = output.PrintJSON(rawJSON)
@@ -90,7 +87,6 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := client.DeleteAlias(id); err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/alias/edit.go
+++ b/cmd/alias/edit.go
@@ -57,14 +57,12 @@ func init() {
 func runEdit(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	id, err := client.ResolveAliasID(args[0])
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
@@ -100,7 +98,6 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := client.UpdateAlias(id, req); err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/alias/list.go
+++ b/cmd/alias/list.go
@@ -65,7 +65,6 @@ func init() {
 func runList(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
@@ -74,7 +73,6 @@ func runList(cmd *cobra.Command, args []string) error {
 	if listAll {
 		aliases, err := client.ListAllAliases(listPinned, listDisabled, listEnabled, listQuery)
 		if err != nil {
-			output.PrintError("%v", err)
 			return err
 		}
 
@@ -93,7 +91,6 @@ func runList(cmd *cobra.Command, args []string) error {
 
 	aliases, rawJSON, err := client.ListAliases(listPage-1, listPinned, listDisabled, listEnabled, listQuery)
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/alias/toggle.go
+++ b/cmd/alias/toggle.go
@@ -44,20 +44,17 @@ func init() {
 func runToggle(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	id, err := client.ResolveAliasID(args[0])
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	enabled, rawJSON, err := client.ToggleAlias(id)
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/alias/view.go
+++ b/cmd/alias/view.go
@@ -49,20 +49,17 @@ func init() {
 func runView(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	id, err := client.ResolveAliasID(args[0])
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	alias, rawJSON, err := client.GetAlias(id)
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -66,8 +66,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		}
 
 		if err := intauth.SaveOPRef(loginVault, loginItem); err != nil {
-			output.PrintError("Failed to save 1Password reference: %v", err)
-			return err
+			return fmt.Errorf("failed to save 1Password reference: %w", err)
 		}
 
 		// Validate by trying to get the key and calling the API
@@ -92,9 +91,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	key := loginKey
 	if key == "" {
 		if !output.IsInteractive() {
-			err := fmt.Errorf("no API key provided. Use: sl auth login --key <api-key>")
-			output.PrintError("%v", err)
-			return err
+			return fmt.Errorf("no API key provided; use: sl auth login --key <api-key>")
 		}
 		// Interactive mode
 		fmt.Fprint(os.Stderr, "Enter your SimpleLogin API key: ")
@@ -111,14 +108,12 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	client := api.NewClient(key)
 	info, _, err := client.GetUserInfo()
 	if err != nil {
-		output.PrintError("Invalid API key: %v", err)
-		return err
+		return fmt.Errorf("invalid API key: %w", err)
 	}
 
 	// Save the key
 	if err := intauth.SaveAPIKey(key); err != nil {
-		output.PrintError("Failed to save API key: %v", err)
-		return err
+		return fmt.Errorf("failed to save API key: %w", err)
 	}
 
 	output.PrintSuccess("Authenticated as %s (%s)", info.Name, info.Email)

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"fmt"
+
 	"github.com/mexcool/simplelogin-cli/internal/api"
 	intauth "github.com/mexcool/simplelogin-cli/internal/auth"
 	"github.com/mexcool/simplelogin-cli/internal/output"
@@ -32,8 +34,7 @@ func runLogout(cmd *cobra.Command, args []string) error {
 
 	// Clear local config
 	if err := intauth.ClearConfig(); err != nil {
-		output.PrintError("Failed to clear config: %v", err)
-		return err
+		return fmt.Errorf("failed to clear config: %w", err)
 	}
 
 	output.PrintSuccess("Logged out successfully")

--- a/cmd/auth/status.go
+++ b/cmd/auth/status.go
@@ -26,8 +26,7 @@ obtaining the API key (environment variable, 1Password, or config file).`,
 func runStatus(cmd *cobra.Command, args []string) error {
 	key, err := intauth.GetAPIKey()
 	if err != nil {
-		output.PrintError("Not authenticated: %v", err)
-		return err
+		return fmt.Errorf("not authenticated: %w (run 'sl auth login' to authenticate)", err)
 	}
 
 	// Determine key source
@@ -43,8 +42,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	client := api.NewClient(key)
 	info, _, err := client.GetUserInfo()
 	if err != nil {
-		output.PrintError("Failed to validate key: %v", err)
-		return err
+		return fmt.Errorf("failed to validate API key: %w", err)
 	}
 
 	fmt.Fprintf(os.Stderr, "Authenticated as: %s (%s)\n", output.Bold.Sprint(info.Name), info.Email)

--- a/cmd/contact/add.go
+++ b/cmd/contact/add.go
@@ -42,20 +42,17 @@ func init() {
 func runAdd(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	aliasID, err := client.ResolveAliasID(args[0])
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	contact, rawJSON, err := client.CreateContact(aliasID, args[1])
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/contact/delete.go
+++ b/cmd/contact/delete.go
@@ -52,12 +52,11 @@ func init() {
 func runDelete(cmd *cobra.Command, args []string) error {
 	id, err := strconv.Atoi(args[0])
 	if err != nil {
-		return fmt.Errorf("invalid contact ID: %s", args[0])
+		return fmt.Errorf("invalid contact ID %q: expected a numeric ID (use 'sl contact list <alias>' to find IDs)", args[0])
 	}
 
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
@@ -81,7 +80,6 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 	client := api.NewClient(key)
 	if err := client.DeleteContact(id); err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/contact/list.go
+++ b/cmd/contact/list.go
@@ -52,21 +52,18 @@ func init() {
 func runList(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	aliasID, err := client.ResolveAliasID(args[0])
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	if listAll {
 		contacts, err := client.GetAllAliasContacts(aliasID)
 		if err != nil {
-			output.PrintError("%v", err)
 			return err
 		}
 
@@ -84,7 +81,6 @@ func runList(cmd *cobra.Command, args []string) error {
 
 	contacts, rawJSON, err := client.GetAliasContacts(aliasID, listPage-1)
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/contact/toggle.go
+++ b/cmd/contact/toggle.go
@@ -41,19 +41,17 @@ func init() {
 func runToggle(cmd *cobra.Command, args []string) error {
 	id, err := strconv.Atoi(args[0])
 	if err != nil {
-		return fmt.Errorf("invalid contact ID: %s", args[0])
+		return fmt.Errorf("invalid contact ID %q: expected a numeric ID (use 'sl contact list <alias>' to find IDs)", args[0])
 	}
 
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	blocked, rawJSON, err := client.ToggleContact(id)
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/domain/edit.go
+++ b/cmd/domain/edit.go
@@ -63,12 +63,11 @@ func init() {
 func runEdit(cmd *cobra.Command, args []string) error {
 	id, err := strconv.Atoi(args[0])
 	if err != nil {
-		return fmt.Errorf("invalid domain ID: %s", args[0])
+		return fmt.Errorf("invalid domain ID %q: expected a numeric ID (use 'sl domain list' to find IDs)", args[0])
 	}
 
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
@@ -107,7 +106,6 @@ func runEdit(cmd *cobra.Command, args []string) error {
 
 	client := api.NewClient(key)
 	if err := client.UpdateCustomDomain(id, req); err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/domain/list.go
+++ b/cmd/domain/list.go
@@ -41,14 +41,12 @@ func init() {
 func runList(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	domains, rawJSON, err := client.ListCustomDomains()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/domain/trash.go
+++ b/cmd/domain/trash.go
@@ -41,19 +41,17 @@ func init() {
 func runTrash(cmd *cobra.Command, args []string) error {
 	id, err := strconv.Atoi(args[0])
 	if err != nil {
-		return fmt.Errorf("invalid domain ID: %s", args[0])
+		return fmt.Errorf("invalid domain ID %q: expected a numeric ID (use 'sl domain list' to find IDs)", args[0])
 	}
 
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	aliases, rawJSON, err := client.GetDomainTrash(id)
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/export/aliases.go
+++ b/cmd/export/aliases.go
@@ -34,21 +34,18 @@ func init() {
 func runAliases(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	data, err := client.ExportAliases()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	if aliasesOutput != "" {
 		if err := os.WriteFile(aliasesOutput, data, 0600); err != nil {
-			output.PrintError("Failed to write file: %v", err)
-			return err
+			return fmt.Errorf("failed to write file %s: %w", aliasesOutput, err)
 		}
 		output.PrintSuccess("Aliases exported to %s", aliasesOutput)
 		return nil

--- a/cmd/export/data.go
+++ b/cmd/export/data.go
@@ -37,21 +37,18 @@ func init() {
 func runData(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	data, err := client.ExportData()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	if dataOutput != "" {
 		if err := os.WriteFile(dataOutput, data, 0600); err != nil {
-			output.PrintError("Failed to write file: %v", err)
-			return err
+			return fmt.Errorf("failed to write file %s: %w", dataOutput, err)
 		}
 		output.PrintSuccess("Data exported to %s", dataOutput)
 		return nil

--- a/cmd/mailbox/add.go
+++ b/cmd/mailbox/add.go
@@ -24,14 +24,12 @@ verify the mailbox before it can be used to receive forwarded emails.`,
 func runAdd(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	_, _, err = client.CreateMailbox(args[0])
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/mailbox/delete.go
+++ b/cmd/mailbox/delete.go
@@ -58,12 +58,11 @@ func init() {
 func runDelete(cmd *cobra.Command, args []string) error {
 	id, err := strconv.Atoi(args[0])
 	if err != nil {
-		return fmt.Errorf("invalid mailbox ID: %s", args[0])
+		return fmt.Errorf("invalid mailbox ID %q: expected a numeric ID (use 'sl mailbox list' to find IDs)", args[0])
 	}
 
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
@@ -72,8 +71,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	if deleteDryRun {
 		mailboxes, _, err := client.ListMailboxes()
 		if err != nil {
-			output.PrintError("Failed to fetch mailboxes for preview: %v", err)
-			return err
+			return fmt.Errorf("failed to fetch mailboxes for preview: %w", err)
 		}
 		var found *api.Mailbox
 		for i := range mailboxes {
@@ -83,7 +81,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 			}
 		}
 		if found == nil {
-			return fmt.Errorf("mailbox not found: %d", id)
+			return fmt.Errorf("mailbox %d not found (use 'sl mailbox list' to see available mailboxes)", id)
 		}
 		if deleteJSON {
 			data, _ := json.Marshal(found)
@@ -112,7 +110,6 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := client.DeleteMailbox(id, transferTo); err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/mailbox/edit.go
+++ b/cmd/mailbox/edit.go
@@ -55,12 +55,11 @@ func init() {
 func runEdit(cmd *cobra.Command, args []string) error {
 	id, err := strconv.Atoi(args[0])
 	if err != nil {
-		return fmt.Errorf("invalid mailbox ID: %s", args[0])
+		return fmt.Errorf("invalid mailbox ID %q: expected a numeric ID (use 'sl mailbox list' to find IDs)", args[0])
 	}
 
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
@@ -89,7 +88,6 @@ func runEdit(cmd *cobra.Command, args []string) error {
 
 	client := api.NewClient(key)
 	if err := client.UpdateMailbox(id, req); err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/mailbox/list.go
+++ b/cmd/mailbox/list.go
@@ -41,14 +41,12 @@ func init() {
 func runList(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	mailboxes, rawJSON, err := client.ListMailboxes()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,8 +36,7 @@ Authentication:
 Output:
   By default, commands display colored table output. Use --json for
   machine-readable JSON output, or --jq to filter JSON with jq expressions.`,
-	SilenceUsage:  true,
-	SilenceErrors: true,
+	SilenceUsage: true,
 }
 
 // SetVersionInfo sets the version string shown by --version, including

--- a/cmd/setting/domains.go
+++ b/cmd/setting/domains.go
@@ -40,14 +40,12 @@ func init() {
 func runDomains(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	domains, rawJSON, err := client.GetAvailableDomains()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/setting/edit.go
+++ b/cmd/setting/edit.go
@@ -58,7 +58,6 @@ func init() {
 func runEdit(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
@@ -94,7 +93,6 @@ func runEdit(cmd *cobra.Command, args []string) error {
 
 	client := api.NewClient(key)
 	if err := client.UpdateSettings(req); err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 

--- a/cmd/setting/view.go
+++ b/cmd/setting/view.go
@@ -34,14 +34,12 @@ func init() {
 func runView(cmd *cobra.Command, args []string) error {
 	key, err := auth.GetAPIKey()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 
 	client := api.NewClient(key)
 	settings, rawJSON, err := client.GetSettings()
 	if err != nil {
-		output.PrintError("%v", err)
 		return err
 	}
 


### PR DESCRIPTION
## Summary

- Removed `SilenceErrors: true` from the root cobra command so Cobra prints errors returned from `RunE` to stderr. `SilenceUsage: true` is kept so usage text does not spam on every error.
- Removed all `output.PrintError(...)` + `return err` patterns from command files to prevent double-printing (Cobra now handles the display).
- Where `output.PrintError` added useful context beyond the raw error (e.g. "Failed to save API key"), converted to `fmt.Errorf("context: %w", err)` so the context is preserved in the error Cobra prints.
- Improved error messages for actionability:
  - Invalid ID errors now tell the user which command to run to find valid IDs (e.g. `use 'sl mailbox list' to find IDs`)
  - Auth errors suggest running `sl auth login`
  - Suffix validation errors show the valid range
  - File write errors include the target path

## Files changed

- `cmd/root.go` -- removed `SilenceErrors: true`
- `cmd/alias/create.go`, `cmd/alias/delete.go`, `cmd/alias/edit.go`, `cmd/alias/toggle.go`, `cmd/alias/list.go`, `cmd/alias/view.go`, `cmd/alias/activity.go` -- removed `output.PrintError` calls, improved error messages
- `cmd/contact/add.go`, `cmd/contact/delete.go`, `cmd/contact/list.go`, `cmd/contact/toggle.go` -- removed `output.PrintError` calls, improved invalid-ID error messages
- `cmd/mailbox/add.go`, `cmd/mailbox/delete.go`, `cmd/mailbox/edit.go`, `cmd/mailbox/list.go` -- removed `output.PrintError` calls, improved error messages
- `cmd/domain/edit.go`, `cmd/domain/list.go`, `cmd/domain/trash.go` -- removed `output.PrintError` calls, improved error messages
- `cmd/auth/login.go`, `cmd/auth/logout.go`, `cmd/auth/status.go` -- removed `output.PrintError` calls, wrapped errors with context
- `cmd/account/status.go` -- removed `output.PrintError` calls
- `cmd/setting/view.go`, `cmd/setting/edit.go`, `cmd/setting/domains.go` -- removed `output.PrintError` calls
- `cmd/export/aliases.go`, `cmd/export/data.go` -- removed `output.PrintError` calls, improved file-write error messages

## Test plan

- [ ] Run `sl alias list` without auth configured -- verify error message is printed to stderr
- [ ] Run `sl contact delete abc` -- verify "invalid contact ID" error with guidance is shown
- [ ] Run `sl mailbox delete xyz` -- verify "invalid mailbox ID" error with guidance is shown
- [ ] Run `sl auth status` without credentials -- verify actionable error mentioning `sl auth login`
- [ ] Run any command with an invalid API key -- verify error is shown (not silently swallowed)
- [ ] Run `sl alias create --prefix test` in non-interactive mode -- verify suffix hint is shown