### PR TITLE
feat: add --jq support to account status and setting view. Closes #12

### DIFF
--- a/cmd/account/status.go
+++ b/cmd/account/status.go
@@ -32,14 +32,21 @@ for all your aliases including total forwards, blocks, and replies.`,
   sl account status
 
   # View as JSON
-  sl account status --json`,
+  sl account status --json
+
+  # Filter JSON output with jq
+  sl account status --json --jq '.name'`,
 	RunE: runStatus,
 }
 
-var statusJSON bool
+var (
+	statusJSON bool
+	statusJQ   string
+)
 
 func init() {
 	statusCmd.Flags().BoolVar(&statusJSON, "json", false, "Output as JSON")
+	statusCmd.Flags().StringVar(&statusJQ, "jq", "", "Apply jq expression to JSON output")
 	Cmd.AddCommand(statusCmd)
 }
 
@@ -60,7 +67,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if statusJSON {
+	if statusJSON || statusJQ != "" {
 		// Merge info and stats into one JSON object
 		var combined map[string]interface{}
 		json.Unmarshal(infoJSON, &combined)
@@ -69,9 +76,11 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		for k, v := range statsMap {
 			combined[k] = v
 		}
-		data, _ := json.MarshalIndent(combined, "", "  ")
-		fmt.Println(string(data))
-		return nil
+		data, _ := json.Marshal(combined)
+		if statusJQ != "" {
+			return output.PrintJQ(data, statusJQ)
+		}
+		return output.PrintJSON(data)
 	}
 
 	premium := "no"

--- a/cmd/setting/view.go
+++ b/cmd/setting/view.go
@@ -21,14 +21,21 @@ for random aliases, sender format, and random alias suffix type.`,
   sl setting view
 
   # View as JSON
-  sl setting view --json`,
+  sl setting view --json
+
+  # Filter JSON output with jq
+  sl setting view --json --jq '.alias_generator'`,
 	RunE: runView,
 }
 
-var viewJSON bool
+var (
+	viewJSON bool
+	viewJQ   string
+)
 
 func init() {
 	viewCmd.Flags().BoolVar(&viewJSON, "json", false, "Output as JSON")
+	viewCmd.Flags().StringVar(&viewJQ, "jq", "", "Apply jq expression to JSON output")
 }
 
 func runView(cmd *cobra.Command, args []string) error {
@@ -43,7 +50,10 @@ func runView(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if viewJSON {
+	if viewJSON || viewJQ != "" {
+		if viewJQ != "" {
+			return output.PrintJQ(rawJSON, viewJQ)
+		}
 		return output.PrintJSON(rawJSON)
 	}
 


### PR DESCRIPTION
## Summary

- Adds `--jq` flag to `account status` command
- Adds `--jq` flag to `setting view` command
- Both commands now follow the same `--jq` pattern used in `alias list` and other commands: when `--jq` is provided, the JSON output is piped through `output.PrintJQ`

## Changes

- `cmd/account/status.go`: Added `statusJQ string` variable, registered `--jq` flag, updated the JSON branch to check `statusJQ != ""` and call `output.PrintJQ`. Also updated the example section and changed `json.MarshalIndent` to `json.Marshal` (formatting is handled by `output.PrintJSON`).
- `cmd/setting/view.go`: Added `viewJQ string` variable, registered `--jq` flag, updated the JSON branch to check `viewJQ != ""` and call `output.PrintJQ`. Updated the example section accordingly.

## Usage examples

```
# Filter account status with jq
sl account status --json --jq '.name'

# Filter settings with jq
sl setting view --json --jq '.alias_generator'
```