### PR TITLE
feat: add CI with GitHub Actions. Closes #7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  ci:
+    name: Build, Test & Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs on every push to `main` and on all pull requests
- Runs `go build ./...`, `go test ./...`, and `go vet ./...` against Go 1.24
- Uses `golangci/golangci-lint-action@v6` for comprehensive linting

## Files affected

- `.github/workflows/ci.yml` (new)