### PR TITLE
fix: nil map panic, Truncate panic, cancelled-delete exit code. Closes #31

### DIFF
--- a/cmd/account/status.go
+++ b/cmd/account/status.go
@@ -69,10 +69,14 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	if statusJSON || statusJQ != "" {
 		// Merge info and stats into one JSON object
-		var combined map[string]interface{}
-		json.Unmarshal(infoJSON, &combined)
+		combined := make(map[string]interface{})
+		if err := json.Unmarshal(infoJSON, &combined); err != nil {
+			return fmt.Errorf("failed to parse user info JSON: %w", err)
+		}
 		var statsMap map[string]interface{}
-		json.Unmarshal(statsJSON, &statsMap)
+		if err := json.Unmarshal(statsJSON, &statsMap); err != nil {
+			return fmt.Errorf("failed to parse stats JSON: %w", err)
+		}
 		for k, v := range statsMap {
 			combined[k] = v
 		}

--- a/cmd/alias/delete.go
+++ b/cmd/alias/delete.go
@@ -81,8 +81,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 	if !deleteYes {
 		if !output.ConfirmAction("Delete alias " + args[0] + "?") {
-			output.PrintWarning("Cancelled")
-			return nil
+			return fmt.Errorf("operation cancelled")
 		}
 	}
 

--- a/cmd/contact/delete.go
+++ b/cmd/contact/delete.go
@@ -73,8 +73,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 	if !deleteYes {
 		if !output.ConfirmAction(fmt.Sprintf("Delete contact %d?", id)) {
-			output.PrintWarning("Cancelled")
-			return nil
+			return fmt.Errorf("operation cancelled")
 		}
 	}
 

--- a/cmd/mailbox/delete.go
+++ b/cmd/mailbox/delete.go
@@ -99,8 +99,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 	if !deleteYes {
 		if !output.ConfirmAction(fmt.Sprintf("Delete mailbox %d?", id)) {
-			output.PrintWarning("Cancelled")
-			return nil
+			return fmt.Errorf("operation cancelled")
 		}
 	}
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -204,6 +204,9 @@ func Truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
+	if maxLen < 4 {
+		return s[:maxLen]
+	}
 	return s[:maxLen-3] + "..."
 }
 

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -70,6 +70,10 @@ func TestTruncate(t *testing.T) {
 		{"hello world, this is long", 10, "hello w..."},
 		{"abc", 3, "abc"},
 		{"abcdef", 5, "ab..."},
+		{"hello", 0, ""},
+		{"hello", 1, "h"},
+		{"hello", 2, "he"},
+		{"hello", 3, "hel"},
 	}
 	for _, tt := range tests {
 		got := Truncate(tt.input, tt.maxLen)


### PR DESCRIPTION
## Summary

Fixes three bugs reported in #31:

### 1. Nil map panic in `account status --json`

`cmd/account/status.go` declared `var combined map[string]interface{}` without initializing it. If `json.Unmarshal` failed (or even on success with certain inputs), assigning into `combined` would panic. Fixed by initializing with `make(map[string]interface{})` and checking errors from both `json.Unmarshal` calls, returning early if either fails.

### 2. `Truncate` panics for `maxLen < 3`

`internal/output/output.go` — `Truncate` computed `s[:maxLen-3]` which produces a negative slice index when `maxLen < 3`, causing a panic. Added a guard: if `maxLen < 4`, return `s[:maxLen]` (truncate without ellipsis since there is no room for "..."). Added test cases for `maxLen` values 0, 1, 2, and 3.

### 3. Cancelled destructive operations exit 0

`cmd/alias/delete.go`, `cmd/contact/delete.go`, `cmd/mailbox/delete.go` — when the user cancels a delete (says "N" or runs non-interactively without `--yes`), the command returned `nil`, causing exit code 0. Scripts checking `$?` would incorrectly think the operation succeeded. Changed all three to return `fmt.Errorf("operation cancelled")` so cobra prints the error and exits non-zero.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (including new Truncate test cases)
- [x] `go vet ./...` passes