### PR TITLE
refactor: replace hand-rolled string helpers with stdlib. Closes #33

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/mexcool/simplelogin-cli/cmd/account"
 	"github.com/mexcool/simplelogin-cli/cmd/alias"
@@ -61,21 +62,9 @@ func SetVersionInfo(v, commit, date string) {
 		if date != "" {
 			parts = append(parts, date)
 		}
-		display = fmt.Sprintf("%s (%s)", v, joinStrings(parts, ", "))
+		display = fmt.Sprintf("%s (%s)", v, strings.Join(parts, ", "))
 	}
 	rootCmd.Version = display
-}
-
-// joinStrings concatenates strings with a separator (avoids importing strings package for one call).
-func joinStrings(elems []string, sep string) string {
-	if len(elems) == 0 {
-		return ""
-	}
-	result := elems[0]
-	for _, e := range elems[1:] {
-		result += sep + e
-	}
-	return result
 }
 
 // Execute runs the root command.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -94,22 +95,7 @@ func wrapNetworkError(err error) error {
 
 // isConnectionRefused reports whether err represents a "connection refused" syscall error.
 func isConnectionRefused(err error) bool {
-	// The most portable check is a string match on the syscall error message.
-	return err != nil && (err.Error() == "connection refused" ||
-		containsString(err.Error(), "connection refused"))
-}
-
-// containsString is a simple helper to avoid importing "strings" just for this.
-func containsString(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr ||
-		func() bool {
-			for i := 0; i <= len(s)-len(substr); i++ {
-				if s[i:i+len(substr)] == substr {
-					return true
-				}
-			}
-			return false
-		}())
+	return err != nil && strings.Contains(err.Error(), "connection refused")
 }
 
 func (c *Client) do(method, path string, body interface{}) ([]byte, int, error) {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -399,26 +399,27 @@ func TestClient_ListMailboxes(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// containsString helper
+// isConnectionRefused helper
 // ---------------------------------------------------------------------------
 
-func TestContainsString(t *testing.T) {
+func TestIsConnectionRefused(t *testing.T) {
 	tests := []struct {
-		s, substr string
-		want      bool
+		name string
+		err  error
+		want bool
 	}{
-		{"connection refused", "connection refused", true},
-		{"dial tcp: connection refused", "connection refused", true},
-		{"timeout", "connection refused", false},
-		{"", "x", false},
-		{"x", "", true},
-		{"", "", true},
+		{"nil error", nil, false},
+		{"exact match", fmt.Errorf("connection refused"), true},
+		{"substring match", fmt.Errorf("dial tcp: connection refused"), true},
+		{"no match", fmt.Errorf("timeout"), false},
 	}
 	for _, tt := range tests {
-		got := containsString(tt.s, tt.substr)
-		if got != tt.want {
-			t.Errorf("containsString(%q, %q) = %v, want %v", tt.s, tt.substr, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			got := isConnectionRefused(tt.err)
+			if got != tt.want {
+				t.Errorf("isConnectionRefused(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Deleted `containsString` in `internal/api/client.go` (hand-rolled `strings.Contains`) and simplified `isConnectionRefused` to use `strings.Contains` directly.
- Deleted `joinStrings` in `cmd/root.go` (hand-rolled `strings.Join`) and replaced its call site in `SetVersionInfo` with `strings.Join`.
- Replaced `TestContainsString` with `TestIsConnectionRefused` in `internal/api/client_test.go` to test the remaining exported-ish helper.

## Verification

- `go build ./...` compiles cleanly
- `go test ./...` passes
- `go vet ./...` passes
- Grepped codebase: zero remaining references to `containsString` or `joinStrings`