### PR TITLE
fix: CI and build improvements. Closes #35

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: go build ./...
 
       - name: Test
-        run: go test ./...
+        run: go test -race ./...
 
       - name: Vet
         run: go vet ./...
@@ -32,4 +32,4 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,16 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: "1.24"
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -race ./...
+
+      - name: Vet
+        run: go vet ./...
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ man/
 # Go
 *.test
 *.out
+coverage.out
 
 # Claude Code
 .claude/worktrees/

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ LDFLAGS := -s -w \
 build:
 	go build -ldflags="$(LDFLAGS)" -o bin/sl ./cmd/sl
 
+PREFIX ?= /usr/local
 install: build
-	cp bin/sl /usr/local/bin/sl
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install -m 755 bin/sl $(DESTDIR)$(PREFIX)/bin/sl
 
 test:
 	go test ./...
@@ -19,7 +21,20 @@ test:
 man:
 	go run ./cmd/gen-man man/
 
+lint:
+	golangci-lint run ./...
+
+fmt:
+	gofmt -w .
+
+vet:
+	go vet ./...
+
+coverage:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out
+
 clean:
 	rm -rf bin/ man/
 
-.PHONY: build install test man clean
+.PHONY: build install test man lint fmt vet coverage clean

--- a/cmd/gen-man/main.go
+++ b/cmd/gen-man/main.go
@@ -28,7 +28,7 @@ func main() {
 	header := &doc.GenManHeader{
 		Title:   "SL",
 		Section: "1",
-		Date:    func() *time.Time { t := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC); return &t }(),
+		Date:    func() *time.Time { t := time.Now().UTC(); return &t }(),
 		Source:  "SimpleLogin CLI",
 		Manual:  "SimpleLogin CLI Manual",
 	}


### PR DESCRIPTION
## Summary

- Add `-race` flag to `go test` in CI workflow for data-race detection
- Pin `golangci-lint` to `v1.64` instead of `latest` for reproducible builds
- Gate releases on build+test+vet in release workflow to prevent shipping broken binaries
- Align Go version to `1.24` (from `go.mod`) in both CI and release workflows
- Add `lint`, `fmt`, `vet`, and `coverage` targets to Makefile
- Fix `install` target to use `$(DESTDIR)$(PREFIX)/bin` instead of hardcoded `/usr/local/bin`
- Update man page date from hardcoded 2024-01-01 to `time.Now().UTC()`
- Add `coverage.out` to `.gitignore`

## Changed files

- `.github/workflows/ci.yml` — race flag, pinned lint version
- `.github/workflows/release.yml` — Go 1.24, build/test/vet gate before goreleaser
- `Makefile` — new targets (lint, fmt, vet, coverage), configurable install prefix
- `cmd/gen-man/main.go` — dynamic man page date
- `.gitignore` — coverage.out