### PR TITLE
feat: agentic UX improvements — exit codes and idempotent commands. Closes #36

### DIFF
--- a/cmd/alias/alias.go
+++ b/cmd/alias/alias.go
@@ -25,6 +25,8 @@ func init() {
 	Cmd.AddCommand(viewCmd)
 	Cmd.AddCommand(deleteCmd)
 	Cmd.AddCommand(toggleCmd)
+	Cmd.AddCommand(enableCmd)
+	Cmd.AddCommand(disableCmd)
 	Cmd.AddCommand(editCmd)
 	Cmd.AddCommand(activityCmd)
 }

--- a/cmd/alias/disable.go
+++ b/cmd/alias/disable.go
@@ -1,0 +1,43 @@
+package alias
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var disableCmd = &cobra.Command{
+	Use:   "disable <alias-id-or-email>",
+	Short: "Disable an alias (idempotent)",
+	Long: `Ensure an alias is disabled. If the alias is already disabled, this is a
+no-op and exits successfully. This is safer than "toggle" for scripting
+and agentic use because it is idempotent — calling it twice has the same
+effect as calling it once.
+
+When disabled, the alias will reject all incoming emails. When enabled,
+emails will be forwarded normally.
+
+Accepts either a numeric alias ID or the full alias email address.`,
+	Example: `  # Disable alias by ID
+  sl alias disable 12345
+
+  # Disable alias by email (idempotent — safe to call repeatedly)
+  sl alias disable my-alias@simplelogin.co
+
+  # Disable and get result as JSON
+  sl alias disable 12345 --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runDisable,
+}
+
+var (
+	disableJSON bool
+	disableJQ   string
+)
+
+func init() {
+	disableCmd.Flags().BoolVar(&disableJSON, "json", false, "Output as JSON")
+	disableCmd.Flags().StringVar(&disableJQ, "jq", "", "Apply jq expression to JSON output")
+}
+
+func runDisable(cmd *cobra.Command, args []string) error {
+	return setAliasState(args[0], false, disableJSON, disableJQ)
+}

--- a/cmd/alias/enable.go
+++ b/cmd/alias/enable.go
@@ -1,0 +1,104 @@
+package alias
+
+import (
+	"fmt"
+
+	"github.com/mexcool/simplelogin-cli/internal/api"
+	"github.com/mexcool/simplelogin-cli/internal/auth"
+	"github.com/mexcool/simplelogin-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var enableCmd = &cobra.Command{
+	Use:   "enable <alias-id-or-email>",
+	Short: "Enable an alias (idempotent)",
+	Long: `Ensure an alias is enabled. If the alias is already enabled, this is a
+no-op and exits successfully. This is safer than "toggle" for scripting
+and agentic use because it is idempotent — calling it twice has the same
+effect as calling it once.
+
+Accepts either a numeric alias ID or the full alias email address.`,
+	Example: `  # Enable alias by ID
+  sl alias enable 12345
+
+  # Enable alias by email (idempotent — safe to call repeatedly)
+  sl alias enable my-alias@simplelogin.co
+
+  # Enable and get result as JSON
+  sl alias enable 12345 --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runEnable,
+}
+
+var (
+	enableJSON bool
+	enableJQ   string
+)
+
+func init() {
+	enableCmd.Flags().BoolVar(&enableJSON, "json", false, "Output as JSON")
+	enableCmd.Flags().StringVar(&enableJQ, "jq", "", "Apply jq expression to JSON output")
+}
+
+func runEnable(cmd *cobra.Command, args []string) error {
+	return setAliasState(args[0], true, enableJSON, enableJQ)
+}
+
+// setAliasState ensures an alias is in the desired enabled/disabled state.
+// It reads the current state first and only toggles if needed (idempotent).
+func setAliasState(idOrEmail string, wantEnabled bool, jsonFlag bool, jqExpr string) error {
+	key, err := auth.GetAPIKey()
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(key)
+	id, err := client.ResolveAliasID(idOrEmail)
+	if err != nil {
+		return err
+	}
+
+	alias, rawJSON, err := client.GetAlias(id)
+	if err != nil {
+		return err
+	}
+
+	verb := "enabled"
+	if !wantEnabled {
+		verb = "disabled"
+	}
+
+	if alias.Enabled == wantEnabled {
+		// Already in the desired state — idempotent success.
+		if jqExpr != "" {
+			return output.PrintJQ(rawJSON, jqExpr)
+		}
+		if jsonFlag {
+			return output.PrintJSON(rawJSON)
+		}
+		output.PrintSuccess("Alias %s is already %s", idOrEmail, verb)
+		fmt.Printf("enabled=%v\n", alias.Enabled)
+		return nil
+	}
+
+	// Toggle to reach the desired state.
+	enabled, rawJSON, err := client.ToggleAlias(id)
+	if err != nil {
+		return err
+	}
+
+	if jqExpr != "" {
+		return output.PrintJQ(rawJSON, jqExpr)
+	}
+	if jsonFlag {
+		return output.PrintJSON(rawJSON)
+	}
+
+	if enabled {
+		output.PrintSuccess("Alias %s is now enabled", idOrEmail)
+	} else {
+		output.PrintWarning("Alias %s is now disabled", idOrEmail)
+	}
+	fmt.Printf("enabled=%v\n", enabled)
+	return nil
+}

--- a/cmd/contact/block.go
+++ b/cmd/contact/block.go
@@ -1,0 +1,100 @@
+package contact
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/mexcool/simplelogin-cli/internal/api"
+	"github.com/mexcool/simplelogin-cli/internal/auth"
+	"github.com/mexcool/simplelogin-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var blockCmd = &cobra.Command{
+	Use:   "block <contact-id>",
+	Short: "Block a contact (idempotent)",
+	Long: `Ensure a contact is blocked. If the contact is already blocked, this is a
+no-op and exits successfully. This is safer than "toggle" for scripting
+and agentic use because it is idempotent — calling it twice has the same
+effect as calling it once.
+
+When a contact is blocked, emails from that address to your alias will
+be rejected.
+
+Use "sl contact list <alias>" to find contact IDs.`,
+	Example: `  # Block a contact
+  sl contact block 456
+
+  # Block and get result as JSON
+  sl contact block 456 --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runBlock,
+}
+
+var (
+	blockJSON bool
+	blockJQ   string
+)
+
+func init() {
+	blockCmd.Flags().BoolVar(&blockJSON, "json", false, "Output as JSON")
+	blockCmd.Flags().StringVar(&blockJQ, "jq", "", "Apply jq expression to JSON output")
+}
+
+func runBlock(cmd *cobra.Command, args []string) error {
+	return setContactBlockState(args[0], true, blockJSON, blockJQ)
+}
+
+// setContactBlockState ensures a contact is in the desired blocked/unblocked state.
+//
+// The SimpleLogin API does not expose a "get single contact" endpoint, so we
+// cannot read the current state before toggling. Instead we call toggle and
+// check the resulting state. If the result is not what we want, we toggle once
+// more. This means at most two API calls to guarantee the desired state, and is
+// still idempotent from the caller's perspective.
+func setContactBlockState(idStr string, wantBlocked bool, jsonFlag bool, jqExpr string) error {
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		return fmt.Errorf("invalid contact ID %q: expected a numeric ID (use 'sl contact list <alias>' to find IDs)", idStr)
+	}
+
+	key, err := auth.GetAPIKey()
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(key)
+
+	blocked, rawJSON, err := client.ToggleContact(id)
+	if err != nil {
+		return err
+	}
+
+	// If the first toggle landed us in the wrong state, toggle again.
+	if blocked != wantBlocked {
+		blocked, rawJSON, err = client.ToggleContact(id)
+		if err != nil {
+			return err
+		}
+	}
+
+	verb := "blocked"
+	if !wantBlocked {
+		verb = "unblocked"
+	}
+
+	if jqExpr != "" {
+		return output.PrintJQ(rawJSON, jqExpr)
+	}
+	if jsonFlag {
+		return output.PrintJSON(rawJSON)
+	}
+
+	if blocked {
+		output.PrintWarning("Contact %d is now %s", id, verb)
+	} else {
+		output.PrintSuccess("Contact %d is now %s", id, verb)
+	}
+	fmt.Printf("blocked=%v\n", blocked)
+	return nil
+}

--- a/cmd/contact/contact.go
+++ b/cmd/contact/contact.go
@@ -24,4 +24,6 @@ func init() {
 	Cmd.AddCommand(addCmd)
 	Cmd.AddCommand(deleteCmd)
 	Cmd.AddCommand(toggleCmd)
+	Cmd.AddCommand(blockCmd)
+	Cmd.AddCommand(unblockCmd)
 }

--- a/cmd/contact/unblock.go
+++ b/cmd/contact/unblock.go
@@ -1,0 +1,39 @@
+package contact
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var unblockCmd = &cobra.Command{
+	Use:   "unblock <contact-id>",
+	Short: "Unblock a contact (idempotent)",
+	Long: `Ensure a contact is unblocked. If the contact is already unblocked, this
+is a no-op and exits successfully. This is safer than "toggle" for
+scripting and agentic use because it is idempotent — calling it twice
+has the same effect as calling it once.
+
+When unblocked, emails from the contact to your alias flow normally.
+
+Use "sl contact list <alias>" to find contact IDs.`,
+	Example: `  # Unblock a contact
+  sl contact unblock 456
+
+  # Unblock and get result as JSON
+  sl contact unblock 456 --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runUnblock,
+}
+
+var (
+	unblockJSON bool
+	unblockJQ   string
+)
+
+func init() {
+	unblockCmd.Flags().BoolVar(&unblockJSON, "json", false, "Output as JSON")
+	unblockCmd.Flags().StringVar(&unblockJQ, "jq", "", "Apply jq expression to JSON output")
+}
+
+func runUnblock(cmd *cobra.Command, args []string) error {
+	return setContactBlockState(args[0], false, unblockJSON, unblockJQ)
+}

--- a/cmd/sl/main.go
+++ b/cmd/sl/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"runtime/debug"
+	"strings"
 
 	"github.com/mexcool/simplelogin-cli/cmd"
 )
@@ -39,6 +40,19 @@ func main() {
 
 	cmd.SetVersionInfo(version, commit, date)
 	if err := cmd.Execute(); err != nil {
-		os.Exit(1)
+		// Exit code 2 for usage/validation errors (POSIX EX_USAGE convention).
+		// This lets scripts distinguish "I called the CLI wrong" from
+		// "the API returned an error" without parsing stderr.
+		exitCode := 1
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "unknown flag") ||
+			strings.Contains(errMsg, "unknown shorthand flag") ||
+			strings.Contains(errMsg, "unknown command") ||
+			strings.Contains(errMsg, "accepts") || // "accepts N arg(s)"
+			strings.Contains(errMsg, "required flag") ||
+			strings.Contains(errMsg, "invalid argument") {
+			exitCode = 2
+		}
+		os.Exit(exitCode)
 	}
 }


### PR DESCRIPTION
## Summary

- **Exit code 2 for usage errors:** `cmd/sl/main.go` now returns exit code 2 (POSIX `EX_USAGE`) for argument/flag validation errors (unknown flag, unknown command, wrong number of args, required flag missing, invalid argument). All other errors still exit 1. This lets scripts and agents distinguish "I called the CLI wrong" from "the API returned an error" without parsing stderr.

- **Idempotent `alias enable` / `alias disable`:** New subcommands that ensure an alias is in the desired state. They read the current state via `GetAlias` first and only call `ToggleAlias` if needed. Calling `enable` on an already-enabled alias is a no-op (exit 0). Supports `--json` and `--jq`.

- **Idempotent `contact block` / `contact unblock`:** Same pattern for contacts. Since the SimpleLogin API has no "get single contact" endpoint, these call `ToggleContact` and check the result; if it landed in the wrong state, they toggle once more. Supports `--json` and `--jq`.

## Usage examples

```bash
# Exit code 2 for usage errors
sl alias list --badoption; echo $?   # prints 2

# Idempotent alias commands (safe for agents)
sl alias enable 12345                # enables if disabled, no-op if already enabled
sl alias enable my@alias.co --json   # works with email, JSON output
sl alias disable 12345               # disables if enabled, no-op if already disabled

# Idempotent contact commands
sl contact block 456                 # blocks if unblocked, no-op if already blocked
sl contact unblock 456 --json        # unblocks, JSON output
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual: run `sl alias toggle --badoption` and verify exit code is 2
- [ ] Manual: run `sl alias enable <id>` twice — second call should say "already enabled"
- [ ] Manual: run `sl contact block <id>` twice — second call should be idempotent