### PR TITLE
feat: add missing --jq flags and --json to mailbox add and auth status. Closes #32

### DIFF
--- a/cmd/alias/create.go
+++ b/cmd/alias/create.go
@@ -38,7 +38,10 @@ Optionally attach a note, display name, or assign to specific mailboxes.`,
   sl alias create --prefix myalias --suffix 0 --mailbox 123
 
   # Output new alias as JSON
-  sl alias create --random --json`,
+  sl alias create --random --json
+
+  # Filter JSON output with jq
+  sl alias create --random --json --jq '.email'`,
 	RunE: runCreate,
 }
 
@@ -50,6 +53,7 @@ var (
 	createNote    string
 	createName    string
 	createJSON    bool
+	createJQ      string
 )
 
 func init() {
@@ -60,6 +64,7 @@ func init() {
 	createCmd.Flags().StringVar(&createNote, "note", "", "Note for the alias")
 	createCmd.Flags().StringVar(&createName, "name", "", "Display name for the alias")
 	createCmd.Flags().BoolVar(&createJSON, "json", false, "Output as JSON")
+	createCmd.Flags().StringVar(&createJQ, "jq", "", "Apply jq expression to JSON output")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -76,7 +81,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		if createJSON {
+		if createJSON || createJQ != "" {
+			if createJQ != "" {
+				return output.PrintJQ(rawJSON, createJQ)
+			}
 			return output.PrintJSON(rawJSON)
 		}
 
@@ -163,7 +171,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if createJSON {
+	if createJSON || createJQ != "" {
+		if createJQ != "" {
+			return output.PrintJQ(rawJSON, createJQ)
+		}
 		return output.PrintJSON(rawJSON)
 	}
 

--- a/cmd/alias/delete.go
+++ b/cmd/alias/delete.go
@@ -32,7 +32,10 @@ Accepts either a numeric alias ID or the full alias email address.`,
   sl alias delete 12345 --dry-run
 
   # Delete and get JSON confirmation
-  sl alias delete 12345 --yes --json`,
+  sl alias delete 12345 --yes --json
+
+  # Filter JSON output with jq
+  sl alias delete 12345 --yes --json --jq '.id'`,
 	Args: cobra.ExactArgs(1),
 	RunE: runDelete,
 }
@@ -40,12 +43,14 @@ Accepts either a numeric alias ID or the full alias email address.`,
 var (
 	deleteYes    bool
 	deleteJSON   bool
+	deleteJQ     string
 	deleteDryRun bool
 )
 
 func init() {
 	deleteCmd.Flags().BoolVar(&deleteYes, "yes", false, "Skip confirmation prompt")
 	deleteCmd.Flags().BoolVar(&deleteJSON, "json", false, "Output as JSON")
+	deleteCmd.Flags().StringVar(&deleteJQ, "jq", "", "Apply jq expression to JSON output")
 	deleteCmd.Flags().BoolVar(&deleteDryRun, "dry-run", false, "Preview without deleting")
 }
 
@@ -66,8 +71,12 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to fetch alias for preview: %w", err)
 		}
-		if deleteJSON {
-			_ = output.PrintJSON(rawJSON)
+		if deleteJSON || deleteJQ != "" {
+			if deleteJQ != "" {
+				_ = output.PrintJQ(rawJSON, deleteJQ)
+			} else {
+				_ = output.PrintJSON(rawJSON)
+			}
 		} else {
 			fmt.Fprintln(os.Stdout, "Would delete alias:")
 			fmt.Fprintf(os.Stdout, "  ID:     %d\n", alias.ID)
@@ -90,10 +99,12 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if deleteJSON {
+	if deleteJSON || deleteJQ != "" {
 		data, _ := json.Marshal(map[string]interface{}{"deleted": true, "id": id})
-		fmt.Println(string(data))
-		return nil
+		if deleteJQ != "" {
+			return output.PrintJQ(data, deleteJQ)
+		}
+		return output.PrintJSON(data)
 	}
 	output.PrintSuccess("Alias deleted")
 	fmt.Println(id)

--- a/cmd/auth/status.go
+++ b/cmd/auth/status.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -19,8 +20,24 @@ user's name and email, and the source of the API key.
 This is useful to verify which account is active and how the CLI is
 obtaining the API key (environment variable, 1Password, or config file).`,
 	Example: `  # Check authentication status
-  sl auth status`,
+  sl auth status
+
+  # Output as JSON
+  sl auth status --json
+
+  # Filter JSON output with jq
+  sl auth status --json --jq '.email'`,
 	RunE: runStatus,
+}
+
+var (
+	statusJSON bool
+	statusJQ   string
+)
+
+func init() {
+	statusCmd.Flags().BoolVar(&statusJSON, "json", false, "Output as JSON")
+	statusCmd.Flags().StringVar(&statusJQ, "jq", "", "Apply jq expression to JSON output")
 }
 
 func runStatus(cmd *cobra.Command, args []string) error {
@@ -43,6 +60,21 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	info, _, err := client.GetUserInfo()
 	if err != nil {
 		return fmt.Errorf("failed to validate API key: %w", err)
+	}
+
+	if statusJSON || statusJQ != "" {
+		data := make(map[string]interface{})
+		data["name"] = info.Name
+		data["email"] = info.Email
+		data["is_premium"] = info.IsPremium
+		data["in_trial"] = info.InTrial
+		data["key_source"] = source
+		data["key"] = intauth.MaskKey(key)
+		jsonBytes, _ := json.Marshal(data)
+		if statusJQ != "" {
+			return output.PrintJQ(jsonBytes, statusJQ)
+		}
+		return output.PrintJSON(jsonBytes)
 	}
 
 	fmt.Fprintf(os.Stderr, "Authenticated as: %s (%s)\n", output.Bold.Sprint(info.Name), info.Email)

--- a/cmd/contact/add.go
+++ b/cmd/contact/add.go
@@ -28,15 +28,22 @@ revealing your real email address.`,
   sl contact add my-alias@simplelogin.co friend@example.com
 
   # Get reverse alias as JSON
-  sl contact add 12345 friend@example.com --json`,
+  sl contact add 12345 friend@example.com --json
+
+  # Filter JSON output with jq
+  sl contact add 12345 friend@example.com --json --jq '.reverse_alias_address'`,
 	Args: cobra.ExactArgs(2),
 	RunE: runAdd,
 }
 
-var addJSON bool
+var (
+	addJSON bool
+	addJQ   string
+)
 
 func init() {
 	addCmd.Flags().BoolVar(&addJSON, "json", false, "Output as JSON")
+	addCmd.Flags().StringVar(&addJQ, "jq", "", "Apply jq expression to JSON output")
 }
 
 func runAdd(cmd *cobra.Command, args []string) error {
@@ -56,7 +63,10 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if addJSON {
+	if addJSON || addJQ != "" {
+		if addJQ != "" {
+			return output.PrintJQ(rawJSON, addJQ)
+		}
 		return output.PrintJSON(rawJSON)
 	}
 

--- a/cmd/contact/delete.go
+++ b/cmd/contact/delete.go
@@ -32,7 +32,10 @@ Use "sl contact list <alias>" to find contact IDs.`,
   sl contact delete 456 --dry-run
 
   # Delete and get JSON confirmation
-  sl contact delete 456 --yes --json`,
+  sl contact delete 456 --yes --json
+
+  # Filter JSON output with jq
+  sl contact delete 456 --yes --json --jq '.id'`,
 	Args: cobra.ExactArgs(1),
 	RunE: runDelete,
 }
@@ -40,12 +43,14 @@ Use "sl contact list <alias>" to find contact IDs.`,
 var (
 	deleteYes    bool
 	deleteJSON   bool
+	deleteJQ     string
 	deleteDryRun bool
 )
 
 func init() {
 	deleteCmd.Flags().BoolVar(&deleteYes, "yes", false, "Skip confirmation prompt")
 	deleteCmd.Flags().BoolVar(&deleteJSON, "json", false, "Output as JSON")
+	deleteCmd.Flags().StringVar(&deleteJQ, "jq", "", "Apply jq expression to JSON output")
 	deleteCmd.Flags().BoolVar(&deleteDryRun, "dry-run", false, "Preview without deleting")
 }
 
@@ -61,9 +66,13 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if deleteDryRun {
-		if deleteJSON {
+		if deleteJSON || deleteJQ != "" {
 			data, _ := json.Marshal(map[string]interface{}{"id": id})
-			fmt.Println(string(data))
+			if deleteJQ != "" {
+				_ = output.PrintJQ(data, deleteJQ)
+			} else {
+				_ = output.PrintJSON(data)
+			}
 		} else {
 			fmt.Printf("Would delete contact %d\n", id)
 		}
@@ -83,10 +92,12 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if deleteJSON {
+	if deleteJSON || deleteJQ != "" {
 		data, _ := json.Marshal(map[string]interface{}{"deleted": true, "id": id})
-		fmt.Println(string(data))
-		return nil
+		if deleteJQ != "" {
+			return output.PrintJQ(data, deleteJQ)
+		}
+		return output.PrintJSON(data)
 	}
 	output.PrintSuccess("Contact deleted")
 	fmt.Println(id)

--- a/cmd/mailbox/add.go
+++ b/cmd/mailbox/add.go
@@ -1,6 +1,8 @@
 package mailbox
 
 import (
+	"fmt"
+
 	"github.com/mexcool/simplelogin-cli/internal/api"
 	"github.com/mexcool/simplelogin-cli/internal/auth"
 	"github.com/mexcool/simplelogin-cli/internal/output"
@@ -16,9 +18,25 @@ var addCmd = &cobra.Command{
 A verification email will be sent to the provided address. You must
 verify the mailbox before it can be used to receive forwarded emails.`,
 	Example: `  # Add a new mailbox
-  sl mailbox add my-other-email@example.com`,
+  sl mailbox add my-other-email@example.com
+
+  # Add and output as JSON
+  sl mailbox add my-other-email@example.com --json
+
+  # Filter JSON output with jq
+  sl mailbox add my-other-email@example.com --json --jq '.id'`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAdd,
+}
+
+var (
+	addJSON bool
+	addJQ   string
+)
+
+func init() {
+	addCmd.Flags().BoolVar(&addJSON, "json", false, "Output as JSON")
+	addCmd.Flags().StringVar(&addJQ, "jq", "", "Apply jq expression to JSON output")
 }
 
 func runAdd(cmd *cobra.Command, args []string) error {
@@ -28,11 +46,19 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	client := api.NewClient(key)
-	_, _, err = client.CreateMailbox(args[0])
+	mailbox, rawJSON, err := client.CreateMailbox(args[0])
 	if err != nil {
 		return err
 	}
 
+	if addJSON || addJQ != "" {
+		if addJQ != "" {
+			return output.PrintJQ(rawJSON, addJQ)
+		}
+		return output.PrintJSON(rawJSON)
+	}
+
 	output.PrintSuccess("Mailbox added. Check %s for a verification email.", args[0])
+	fmt.Println(mailbox.ID)
 	return nil
 }

--- a/cmd/mailbox/delete.go
+++ b/cmd/mailbox/delete.go
@@ -36,7 +36,10 @@ You will be prompted for confirmation unless --yes is provided.`,
   sl mailbox delete 456 --dry-run
 
   # Delete and get JSON confirmation
-  sl mailbox delete 456 --yes --json`,
+  sl mailbox delete 456 --yes --json
+
+  # Filter JSON output with jq
+  sl mailbox delete 456 --yes --json --jq '.id'`,
 	Args: cobra.ExactArgs(1),
 	RunE: runDelete,
 }
@@ -45,6 +48,7 @@ var (
 	deleteTransferTo int
 	deleteYes        bool
 	deleteJSON       bool
+	deleteJQ         string
 	deleteDryRun     bool
 )
 
@@ -52,6 +56,7 @@ func init() {
 	deleteCmd.Flags().IntVar(&deleteTransferTo, "transfer-to", 0, "Transfer aliases to this mailbox ID")
 	deleteCmd.Flags().BoolVar(&deleteYes, "yes", false, "Skip confirmation prompt")
 	deleteCmd.Flags().BoolVar(&deleteJSON, "json", false, "Output as JSON")
+	deleteCmd.Flags().StringVar(&deleteJQ, "jq", "", "Apply jq expression to JSON output")
 	deleteCmd.Flags().BoolVar(&deleteDryRun, "dry-run", false, "Preview without deleting")
 }
 
@@ -83,9 +88,13 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		if found == nil {
 			return fmt.Errorf("mailbox %d not found (use 'sl mailbox list' to see available mailboxes)", id)
 		}
-		if deleteJSON {
+		if deleteJSON || deleteJQ != "" {
 			data, _ := json.Marshal(found)
-			fmt.Println(string(data))
+			if deleteJQ != "" {
+				_ = output.PrintJQ(data, deleteJQ)
+			} else {
+				_ = output.PrintJSON(data)
+			}
 		} else {
 			fmt.Fprintln(os.Stdout, "Would delete mailbox:")
 			fmt.Fprintf(os.Stdout, "  ID:      %d\n", found.ID)
@@ -113,10 +122,12 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if deleteJSON {
+	if deleteJSON || deleteJQ != "" {
 		data, _ := json.Marshal(map[string]interface{}{"deleted": true, "id": id})
-		fmt.Println(string(data))
-		return nil
+		if deleteJQ != "" {
+			return output.PrintJQ(data, deleteJQ)
+		}
+		return output.PrintJSON(data)
 	}
 	output.PrintSuccess("Mailbox deleted")
 	fmt.Println(id)


### PR DESCRIPTION
## Summary

Adds `--jq` flag to 5 commands that had `--json` but not `--jq`, and adds both `--json` and `--jq` to `mailbox add` and `auth status`.

### Part 1: Add `--jq` to commands that already had `--json`

- **cmd/alias/create.go** — added `createJQ` var, `--jq` flag registration, and `output.PrintJQ` calls in both the random and custom alias code paths
- **cmd/alias/delete.go** — added `deleteJQ` var, `--jq` flag registration, and `output.PrintJQ` calls in both the dry-run and actual delete paths
- **cmd/contact/add.go** — added `addJQ` var, `--jq` flag registration, and `output.PrintJQ` call
- **cmd/contact/delete.go** — added `deleteJQ` var, `--jq` flag registration, and `output.PrintJQ` calls in both the dry-run and actual delete paths
- **cmd/mailbox/delete.go** — added `deleteJQ` var, `--jq` flag registration, and `output.PrintJQ` calls in both the dry-run and actual delete paths

### Part 2: Add `--json` and `--jq` to `mailbox add`

- **cmd/mailbox/add.go** — captured the `mailbox` and `rawJSON` return values from `client.CreateMailbox`, added `--json`/`--jq` flags, outputs JSON when requested, prints the mailbox ID in non-JSON mode

### Part 3: Add `--json` and `--jq` to `auth status`

- **cmd/auth/status.go** — added `--json`/`--jq` flags, builds a JSON object with user info (`name`, `email`, `is_premium`, `in_trial`), key source, and masked key; outputs via `output.PrintJSON`/`output.PrintJQ`

### Verification

- `go build ./...` passes
- `go test ./...` passes
- `go vet ./...` passes