### PR TITLE
fix: rename homebrew formula to simplelogin-cli to avoid conflict with sl

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,7 +61,7 @@ changelog:
       - Merge branch
 
 brews:
-  - name: sl
+  - name: simplelogin-cli
     repository:
       owner: mexcool
       name: homebrew-tap

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ A command-line interface for the [SimpleLogin](https://simplelogin.io) email ali
 ### Homebrew (macOS/Linux)
 
 ```bash
-brew tap mexcool/tap
-brew install sl
+brew install mexcool/tap/simplelogin-cli
 ```
 
 ### Go install


### PR DESCRIPTION
## Problem

`sl` is an existing homebrew core formula (the steam locomotive joke command). Users can't install our CLI without first uninstalling the train.

## Fix

- Rename the brew formula from `sl` to `simplelogin-cli` in `.goreleaser.yaml`
- Update README install instructions to `brew install mexcool/tap/simplelogin-cli`
- The binary is still named `sl` — only the formula name changes